### PR TITLE
Fixes #6 - Memory overload in threads mode

### DIFF
--- a/django_eose/__init__.py
+++ b/django_eose/__init__.py
@@ -1,4 +1,4 @@
 from .search import search_queryset
 
 __all__ = ["search_queryset"]
-__version__ = "0.2.2b1"
+__version__ = "0.2.3b1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "django-eose"
-version = "0.2.2b1"
+version = "0.2.3b1"
 description = "Django Encrypted Object Search Engine."
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
- Fix high memory usage in threads mode.
- Add missing parameters to the run_sync function.
- Remove .all() from the queryset.